### PR TITLE
don't allow newlines in single line comment

### DIFF
--- a/lib/pon-parser.pegjs
+++ b/lib/pon-parser.pegjs
@@ -15,7 +15,7 @@ ignore
   = [\s\r\n ] { return { kind: "whitespace"}; }
 
 singleComment
-  = "<¿--<<" text:[^>]* ">>--?>" { return { kind: "singleLineComment", singleLineComment: text.join('') }; }
+  = "<¿--<<" text:[^>\n\r]* ">>--?>" { return { kind: "singleLineComment", singleLineComment: text.join('') }; }
 
 multiComment
   = "<¡--<<" text:[^>]* ">>--!>" { return { kind: "multiLineComment", multiLineComment: text.join('').replace('\n', '').replace('\r', '') }; }


### PR DESCRIPTION
Currently there are newlines allowed in a single line comment which doesn't makes sense.