### PR TITLE
simplify pegjs

### DIFF
--- a/lib/pon-parser.pegjs
+++ b/lib/pon-parser.pegjs
@@ -21,13 +21,13 @@ multiComment
   = "<¡--<<" text:[^>]* ">>--!>" { return { kind: "multiLineComment", multiLineComment: text.join('').replace('\n', '').replace('\r', '') }; }
 
 declaration
-  = ignore? index:[0-9.]+ ignore depth:[#]+ ignore "<<"? key:[a-zA-Z]+ ">>"? ignore? dec:( valueDefinition / objStart ) { return { kind: "declaration", index: index.join(''), depth: depth.join(''), key: key.join(''), declaration: dec }; }
+  = index:[0-9.]+ ignore depth:[#]+ ignore "<<"? key:[a-zA-Z]+ ">>"? ignore? dec:( valueDefinition / objStart ) { return { kind: "declaration", index: index.join(''), depth: depth.join(''), key: key.join(''), declaration: dec }; }
 
 valueDefinition
-  = ignore? equal:":=" ignore "<<" val:[^>]+ ">>" ignore? { return { kind: "valueDefinition", equal: equal, value: val.join('') }; }
+  = equal:":=" ignore "<<" val:[^>]+ ">>" ignore? { return { kind: "valueDefinition", equal: equal, value: val.join('') }; }
 
 objStart
-  = ignore? "[" { return { kind: "objectStart", objectStart: true }; }
+  = "[" { return { kind: "objectStart", objectStart: true }; }
 
 objEnd
-  = ignore? "];" ignore? { return { kind: "objectEnd", objectEnd: true }; }
+  = "];" ignore? { return { kind: "objectEnd", objectEnd: true }; }


### PR DESCRIPTION
In the pegjs there were some `ignore?` which were already covered so they are not needed.