### PR TITLE
remove npx prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/pon.js",
   "scripts": {
     "post-install": "generate:pegjs",
-    "generate:pegjs": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
+    "generate:pegjs": "pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
   },
   "bin": {
     "pon": "bin/cli.js"


### PR DESCRIPTION
The commands in the `"script"` tag don't need `npx`