### PR TITLE
build on publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules/
+lib/pon-parser.pegjs
 test.js
 test/
 spec/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/pon.js",
   "scripts": {
-    "post-install": "generate:pegjs",
+    "prepair": "generate:pegjs",
     "generate:pegjs": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "main": "lib/pon.js",
   "scripts": {
-    "prepare": "generate:pegjs",
-    "generate:pegjs": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
+    "prepare": "build",
+    "build": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
   },
   "bin": {
     "pon": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/pon.js",
   "scripts": {
-    "prepair": "generate:pegjs",
+    "prepare": "generate:pegjs",
     "generate:pegjs": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "main": "lib/pon.js",
   "scripts": {
-    "prepare": "build",
-    "build": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
+    "prepare": "npm run generate:pegjs",
+    "generate:pegjs": "npx pegjs -o ./lib/pon-parser.js ./lib/pon-parser.pegjs"
   },
   "bin": {
     "pon": "bin/cli.js"


### PR DESCRIPTION
This changes the build process to being on publish and not on install.
When the documentation is correct it should still auto build if installed from github. [doc](https://docs.npmjs.com/cli/v9/using-npm/scripts/#life-cycle-scripts)

The `npm run` seems to be required even though it doesn't makes sense.